### PR TITLE
V1.0.1 cran fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
 	person("Becca", "Krouse", email = "rebecca_krouse@rhoworld.com", role = c("cre","aut")),
 	person("Spencer", "Childress", role = "aut"),
 	person("Jeremy", "Wildfire", role = "aut"),
-	person("Rho, Inc.", role = "cph"))
+	person("Rho Inc.", role = "cph"))
 Maintainer: Becca Krouse <rebecca_krouse@rhoworld.com>
 Description: An R interface for Rho's 'web-codebook' 'JavaScript' charting library, which provides a simple interactive framework for exploring data. datadigest includes two key functions (codebook() and explorer()) that deliver a concise summary of every variable in a data frame, along with interactive features such as real-time filters, grouping, and highlighting. Each function has an associated 'RStudio' addin/'Shiny' app for quick and convenient exploration of one or more data frames.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,14 @@
 Package: datadigest
 Type: Package
-Title: Create an Interactive Data Summary from R
-Version: 1.0.1
+Title: Create an Interactive Data Summary
+Version: 1.0.2
 Authors@R: c(
 	person("Becca", "Krouse", email = "rebecca_krouse@rhoworld.com", role = c("cre","aut")),
-	person("Spencer", "Childress", role = c("aut")),
-	person("Jeremy", "Wildfire", role = c("aut")))
+	person("Spencer", "Childress", role = "aut"),
+	person("Jeremy", "Wildfire", role = "aut"),
+	person("Rho, Inc.", role = "cph"))
 Maintainer: Becca Krouse <rebecca_krouse@rhoworld.com>
-Description: An R interface for Rho's web-codebook JavaScript charting library, which provides a simple interactive framework for exploring data. datadigest includes two key functions (codebook() and explorer()) that deliver a concise summary of every variable in a data frame, along with interactive features such as real-time filters, grouping, and highlighting. Each function has an associated RStudio addin/Shiny app for quick and convenient exploration of one or more data frames.
+Description: An R interface for Rho's 'web-codebook' 'JavaScript' charting library, which provides a simple interactive framework for exploring data. datadigest includes two key functions (codebook() and explorer()) that deliver a concise summary of every variable in a data frame, along with interactive features such as real-time filters, grouping, and highlighting. Each function has an associated 'RStudio' addin/'Shiny' app for quick and convenient exploration of one or more data frames.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,3 @@
-MIT License
+YEAR: 2018 
+COPYRIGHT HOLDER: Rho Inc.
 
-Copyright (c) 2017-2018 Rho Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
 YEAR: 2018 
 COPYRIGHT HOLDER: Rho Inc.
 
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# datadigest 1.0.1
+# datadigest 1.0.2
 
 Initial release for datadigest, an R interface for Rho's [web-codebook](https://github.com/RhoInc/web-codebook) JavaScript library. The r version of the codebook has been built using the [htmlwidgets](htmlwidgets.org) framework and consists of two key functions: ```codebook()``` and ```explorer()```.  ```codebook()``` delivers an interactive interface for a single data frame while ```explorer()``` extends this functionality, allowing the user to navigate through multiple data frames. 
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ library("datadigest")
 explorer(demo = TRUE)
 ```
 
-Note that the name of this repo changed from "rhoinc/codebook" to "rhoinc/datadigest" prior to the release of v1.0 on CRAN. Any links to the codebook repo will automatically redirect. 
+Note that the name of this repo changed from "rhoinc/codebook" to "rhoinc/datadigest" prior to the release of v1.0.2 on CRAN. Any links to the codebook repo will automatically redirect. 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,9 @@
-# Version 1.0.1
-This is the first submission of datadigest.
+# Version 1.0.2
+This is a resubmission of datadigest.  In this version we have:
+
+* Added quotes to software names.
+* Used the CRAN template for the LICENSE file.
+* Indentified the copyright holder in the DECSRIPTION file.
 
 ## Test environments
 * ubuntu 14.04, R 3.5.0 (on travis-ci)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,7 @@
 # Version 1.0.2
 This is a resubmission of datadigest.  In this version we have:
 
+* Omit "from R" from the Title.
 * Added quotes to software names.
 * Used the CRAN template for the LICENSE file.
 * Indentified the copyright holder in the DECSRIPTION file.


### PR DESCRIPTION
Fixes for CRAN feedback.

* Omit "from R" from the Title.
* Added quotes to software names.
* Used the CRAN template for the LICENSE file.
* Indentified the copyright holder in the DECSRIPTION file.